### PR TITLE
feat!: nix flakeでパッケージングしてnix runで利用できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
 # pppset
 
 **p**andoc **p**df **p**age **p**ersonal **p**aranoia **p**rofile **p**reset
-
-# How to use
-
-```
-install.sh
-```
-
-install to `~/.local/bin/`
-
-```
-markdown2article foo.md
-```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # pppset
 
 **p**andoc **p**df **p**age **p**ersonal **p**aranoia **p**rofile **p**reset
+
+## Usage
+
+記事PDFを生成する場合。
+
+```zsh
+nix run 'github:ncaq/pppset#markdown2article' -- foo.md
+```
+
+Beamerスライドを生成する場合。
+
+```zsh
+nix run 'github:ncaq/pppset#markdown2beamer' -- slides.md
+```
+
+引数のMarkdownファイルと同じディレクトリに、
+拡張子を`.pdf`に置き換えたファイルが出力されます。
+
+## Development
+
+ローカルにcloneしている場合は以下のように呼び出せます。
+
+```zsh
+nix run '.#markdown2article' -- foo.md
+nix run '.#markdown2beamer' -- slides.md
+```

--- a/_typos.toml
+++ b/_typos.toml
@@ -7,3 +7,5 @@ HSA = "HSA"
 Hashi = "Hashi"
 # Immediately Invoked Function Expression (IIFE)の略語。camelCase分割で"IIF"をtypoと判定する。
 IIF = "IIF"
+# OpenTypeフォントの"loca"テーブル(glyph location table)の名前。"local"のtypoではない。
+loca = "loca"

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "firge-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765876310,
+        "narHash": "sha256-1ID2zFp0LnP4T2RFZ1dB2fYYOzIH1keVet5jP/aUmNc=",
+        "owner": "ncaq",
+        "repo": "firge-nix",
+        "rev": "f9294236ec07c68192bac1b893c5e9f82d77a14a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ncaq",
+        "repo": "firge-nix",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -51,6 +71,7 @@
     },
     "root": {
       "inputs": {
+        "firge-nix": "firge-nix",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # `firge-nerd-font`はnixpkgs本体に存在しないため、
-    # 公式オーバーレイから取得します。
+    # オーバーレイから取得します。
     firge-nix = {
       url = "github:ncaq/firge-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -6,12 +6,19 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # `firge-nerd-font`はnixpkgs本体に存在しないため、
+    # 公式オーバーレイから取得します。
+    firge-nix = {
+      url = "github:ncaq/firge-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     inputs@{
       flake-parts,
       treefmt-nix,
+      firge-nix,
       ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
@@ -29,6 +36,14 @@
           pkgs,
           ...
         }:
+        let
+          # `firge-nerd-font`を使えるようにオーバーレイを適用したpkgsを派生させます。
+          pkgsWithFirge = pkgs.extend firge-nix.overlays.default;
+
+          pppset = pkgs.callPackage ./nix/pppset.nix {
+            inherit (pkgsWithFirge) firge-nerd-font;
+          };
+        in
         {
           treefmt.config = {
             projectRootFile = "flake.nix";
@@ -57,6 +72,18 @@
             inherit (pkgs)
               nix-fast-build
               ;
+            default = pppset;
+          };
+
+          apps = {
+            markdown2article = {
+              program = pkgs.lib.getExe' pppset "markdown2article";
+              meta.description = "Convert Markdown into a PDF article via pandoc and lualatex";
+            };
+            markdown2beamer = {
+              program = pkgs.lib.getExe' pppset "markdown2beamer";
+              meta.description = "Convert Markdown into a PDF beamer slide deck via pandoc and lualatex";
+            };
           };
 
           devShells.default = pkgs.mkShell {

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -eux
-
-cp src/bin/* ~/.local/bin/
-cp -r src/share/pppset/ ~/.local/share/

--- a/nix/pppset.nix
+++ b/nix/pppset.nix
@@ -9,8 +9,8 @@
   biz-ud-gothic,
   fira,
   firge-nerd-font,
+  noto-fonts,
   noto-fonts-cjk-serif-static,
-  zilla-slab,
 }:
 let
   # 必要なTeX Liveコレクションを束ねます。
@@ -35,8 +35,8 @@ let
     biz-ud-gothic
     fira
     firge-nerd-font
+    noto-fonts
     noto-fonts-cjk-serif-static
-    zilla-slab
   ];
 
   # luaotfloadが参照する`OSFONTDIR`に単一ディレクトリで渡せるよう、複数フォントパッケージを統合します。

--- a/nix/pppset.nix
+++ b/nix/pppset.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  stdenv,
+  makeWrapper,
+  symlinkJoin,
+  writeText,
+  pandoc,
+  texlive,
+  biz-ud-gothic,
+  fira,
+  firge-nerd-font,
+  noto-fonts-cjk-serif-static,
+  zilla-slab,
+}:
+let
+  # 必要なTeX Liveコレクションを束ねます。
+  # `scheme-medium`はbeamerやmicrotypeなど一般的な文書クラスを含み、
+  # `luatexja`はLuaTeX-jaと`ltjarticle`等のクラスを提供します。
+  # `haranoaji`はLuaTeX-jaがデフォルト和文フォントとして読み込むため、
+  # 個別の`\setmainjfont`で上書きする前に必須となります。
+  pppsetTexlive = texlive.combine {
+    inherit (texlive)
+      haranoaji
+      luatexja
+      scheme-medium
+      ;
+  };
+
+  # `article.sty`と`markdown2beamer`が参照するフォント群です。
+  # ロール構成は`~/dotfiles/home/core/font.nix`に揃えています。
+  # `noto-fonts-cjk-serif`の通常版はvariable fontを`.ttc`に詰めた形式で、
+  # luaotfloadが`loca table not found`で読み込みに失敗するため、
+  # ウェイト別に`.ttc`に分かれたstatic版を採用しています。
+  pppsetFonts = [
+    biz-ud-gothic
+    fira
+    firge-nerd-font
+    noto-fonts-cjk-serif-static
+    zilla-slab
+  ];
+
+  # luaotfloadが参照する`OSFONTDIR`に単一ディレクトリで渡せるよう、複数フォントパッケージを統合します。
+  # kpathseaの`$OSFONTDIR//`再帰展開は、コロン区切りの複数パスでは末尾のパスにしか効かない挙動があるため、
+  # `symlinkJoin`でひとつの`share/fonts`ツリーに集約することで全フォントを再帰スキャンの対象にします。
+  pppsetFontDir = symlinkJoin {
+    name = "pppset-fonts";
+    paths = pppsetFonts;
+  };
+
+  # 利用者環境のfontconfigに混入した同名フォント(`Noto Serif CJK JP`のVariable Font版など)を
+  # 拾わないよう、本パッケージ専用の`fonts.conf`で発見対象を限定します。
+  # `nixpkgs.makeFontsConf`は`~/.nix-profile`や`/etc/fonts/conf.d`などをincludeするため、
+  # 隔離目的では使えません。自前で最小限の構成を生成します。
+  pppsetFontsConf = writeText "pppset-fonts.conf" ''
+    <?xml version="1.0"?>
+    <!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+    <fontconfig>
+    ${lib.concatMapStringsSep "\n" (font: "  <dir>${font}/share/fonts</dir>") pppsetFonts}
+      <cachedir prefix="xdg">fontconfig-pppset</cachedir>
+    </fontconfig>
+  '';
+
+  # luaotfloadは`FONTCONFIG_FILE`を経由せず`/etc/fonts/fonts.conf`を直接読み込みOSフォント走査を行うため、
+  # 利用者環境にインストールされた同名のVariable Fontを拾ってしまいます。
+  # `location-precedence`を`texmf`のみに絞ってOSフォント走査を抑止し、
+  # 走査対象を`OSFONTDIR`が指す本パッケージのフォントのみに限定します。
+  pppsetXdgConfig = stdenv.mkDerivation {
+    name = "pppset-xdg-config";
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p $out/luaotfload
+      cat > $out/luaotfload/luaotfload.conf <<'EOF'
+      [db]
+      location-precedence = texmf
+      EOF
+    '';
+  };
+in
+stdenv.mkDerivation {
+  pname = "pppset";
+  version = "0.0.0";
+
+  src = ./..;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 src/bin/markdown2article -t $out/bin/
+    install -Dm755 src/bin/markdown2beamer -t $out/bin/
+    install -Dm644 src/share/pppset/article.sty -t $out/share/pppset/
+    install -Dm644 src/share/pppset/beamer.sty -t $out/share/pppset/
+
+    for script in $out/bin/*; do
+      wrapProgram "$script" \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            pandoc
+            pppsetTexlive
+          ]
+        } \
+        --prefix OSFONTDIR : ${pppsetFontDir}/share/fonts \
+        --set FONTCONFIG_FILE ${pppsetFontsConf} \
+        --set XDG_CONFIG_HOME ${pppsetXdgConfig} \
+        --run ${
+          # luaotfloadのフォント名キャッシュはシステムのfontconfig走査結果を保持しており、
+          # 同名フォントの参照先がvariable font版になっていると本パッケージから読めなくなります。
+          # 専用の`TEXMFCACHE`を割り当てて、隔離したフォント環境から都度再構築させます。
+          lib.escapeShellArg ''
+            export TEXMFCACHE="''${XDG_CACHE_HOME:-$HOME/.cache}/pppset/texmf-var"
+            mkdir -p "$TEXMFCACHE"
+          ''
+        }
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "pandoc pdf page personal paranoia profile preset";
+    homepage = "https://github.com/ncaq/pppset";
+    license = lib.licenses.mit;
+    mainProgram = "markdown2article";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/src/bin/markdown2article
+++ b/src/bin/markdown2article
@@ -1,28 +1,35 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -eux
-setopt EXTENDED_GLOB
+set -x
 
-pandoc\
-  --from markdown\
-  --to latex\
-  --listings\
-  --number-sections\
-  --pdf-engine=lualatex\
-  --template=`dirname $0`/../share/pppset/article.sty\
-  --variable='documentclass:ltjarticle'\
-  --variable='papersize:a4papar'\
-  --variable='geometry:margin=15truemm'\
-  --output=${1:r}.tex\
-  $1
+shopt -s extglob nullglob
 
-lualatex\
-  --draftmode\
-  --interaction=nonstopmode\
-  --shell-escape\
-  ${1:r}.tex
+stem="${1%.*}"
+script_dir="$(dirname "$0")"
 
-lualatex\
-  --interaction=nonstopmode\
-  --shell-escape\
-  ${1:r}.tex ${1:r}.^*(log|md|pdf|tex)*
+pandoc \
+  --from markdown \
+  --to latex \
+  --listings \
+  --number-sections \
+  --pdf-engine=lualatex \
+  --template="$script_dir/../share/pppset/article.sty" \
+  --variable='documentclass:ltjarticle' \
+  --variable='papersize:a4papar' \
+  --variable='geometry:margin=15truemm' \
+  --output="$stem.tex" \
+  "$1"
+
+lualatex \
+  --draftmode \
+  --interaction=nonstopmode \
+  --shell-escape \
+  "$stem.tex"
+
+extras=("$stem".!(*log*|*md*|*pdf*|*tex*))
+
+lualatex \
+  --interaction=nonstopmode \
+  --shell-escape \
+  "$stem.tex" "${extras[@]}"

--- a/src/bin/markdown2article
+++ b/src/bin/markdown2article
@@ -16,7 +16,7 @@ pandoc \
   --pdf-engine=lualatex \
   --template="$script_dir/../share/pppset/article.sty" \
   --variable='documentclass:ltjarticle' \
-  --variable='papersize:a4papar' \
+  --variable='papersize:a4paper' \
   --variable='geometry:margin=15truemm' \
   --output="$stem.tex" \
   "$1"

--- a/src/bin/markdown2beamer
+++ b/src/bin/markdown2beamer
@@ -16,10 +16,10 @@ pandoc \
   --pdf-engine=lualatex \
   --template="$script_dir/../share/pppset/beamer.sty" \
   --variable='luatexjapresetoptions' \
-  --variable='mainfont:HackGen Console NF' \
-  --variable='sansfont:HackGen Console NF' \
-  --variable='monofont:HackGen Console NF' \
-  --variable='CJKmainfont:HackGen Console NF' \
+  --variable='mainfont:Fira Sans' \
+  --variable='sansfont:Fira Sans' \
+  --variable='monofont:FirgeNerd Console' \
+  --variable='CJKmainfont:BIZ UDGothic' \
   --variable='colorlinks' \
   --output="$stem.tex" \
   "$1"

--- a/src/bin/markdown2beamer
+++ b/src/bin/markdown2beamer
@@ -1,31 +1,38 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+set -euo pipefail
 
-set -eux
-setopt EXTENDED_GLOB
+set -x
 
-pandoc\
-  --from markdown\
-  --to beamer\
-  --listings\
-  --number-sections\
-  --pdf-engine=lualatex\
-  --template=`dirname $0`/../share/pppset/beamer.sty\
-  --variable='luatexjapresetoptions'\
-  --variable='mainfont:HackGen Console NF'\
-  --variable='sansfont:HackGen Console NF'\
-  --variable='monofont:HackGen Console NF'\
-  --variable='CJKmainfont:HackGen Console NF'\
-  --variable='colorlinks'\
-  --output=${1:r}.tex\
-  $1
+shopt -s extglob nullglob
 
-lualatex\
-  --draftmode\
-  --interaction=nonstopmode\
-  --shell-escape\
-  ${1:r}.tex
+stem="${1%.*}"
+script_dir="$(dirname "$0")"
 
-lualatex\
-  --interaction=nonstopmode\
-  --shell-escape\
-  ${1:r}.tex ${1:r}.^*(log|md|pdf|tex)*
+pandoc \
+  --from markdown \
+  --to beamer \
+  --listings \
+  --number-sections \
+  --pdf-engine=lualatex \
+  --template="$script_dir/../share/pppset/beamer.sty" \
+  --variable='luatexjapresetoptions' \
+  --variable='mainfont:HackGen Console NF' \
+  --variable='sansfont:HackGen Console NF' \
+  --variable='monofont:HackGen Console NF' \
+  --variable='CJKmainfont:HackGen Console NF' \
+  --variable='colorlinks' \
+  --output="$stem.tex" \
+  "$1"
+
+lualatex \
+  --draftmode \
+  --interaction=nonstopmode \
+  --shell-escape \
+  "$stem.tex"
+
+extras=("$stem".!(*log*|*md*|*pdf*|*tex*))
+
+lualatex \
+  --interaction=nonstopmode \
+  --shell-escape \
+  "$stem.tex" "${extras[@]}"

--- a/src/share/pppset/article.sty
+++ b/src/share/pppset/article.sty
@@ -2,11 +2,13 @@
 
 \usepackage{luatexja}
 \usepackage{luatexja-fontspec}
-\setmainfont{Zilla Slab}
+\setmainfont{Noto Serif}
 \setmainjfont{Noto Serif CJK JP}
 \setmonofont{FirgeNerd Console}
 \setsansfont{Fira Sans}
 \setsansjfont{BIZ UDGothic}
+\renewcommand{\familydefault}{\sfdefault}
+\renewcommand{\kanjifamilydefault}{\gtdefault}
 
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}

--- a/src/share/pppset/article.sty
+++ b/src/share/pppset/article.sty
@@ -2,11 +2,11 @@
 
 \usepackage{luatexja}
 \usepackage{luatexja-fontspec}
-\setmainfont{HackGen Console NF}
-\setmainjfont{HackGen Console NF}
-\setmonofont{HackGen Console NF}
-\setsansfont{HackGen Console NF}
-\setsansjfont{HackGen Console NF}
+\setmainfont{Zilla Slab}
+\setmainjfont{Noto Serif CJK JP}
+\setmonofont{FirgeNerd Console}
+\setsansfont{Fira Sans}
+\setsansjfont{BIZ UDGothic}
 
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}


### PR DESCRIPTION
## 概要

shellscriptベースのインストーラー(`install.sh`)を廃止し、
nix flakeパッケージとして配布する形に切り替えました。
`nix run github:ncaq/pppset#markdown2article`で利用者は依存関係を意識せず実行できます。

## 主な変更点

- `install.sh`を削除して、利用フローをnix flakeに一本化(BREAKING)。
- `src/bin/`のスクリプトをzshからbashへ書き換え、shellcheckで継続的に検査できる状態に。
- `nix/pppset.nix`を追加し、pandoc・LuaTeX-ja・必要なフォントを束ねたパッケージを定義。
  `apps.markdown2article`と`apps.markdown2beamer`を公開。

## LuaTeX-ja環境のフォント解決対応

LuaTeX-jaを動かすにあたり、利用者環境のfontconfigやluaotfloadキャッシュと干渉する問題を回避するための仕掛けを入れています。

- luaotfloadは\`FONTCONFIG_FILE\`を経由せず\`/etc/fonts/fonts.conf\`を直接読むため、\`luaotfload.conf\`で\`location-precedence = texmf\`に固定してOSフォント走査を抑止。
- nixpkgsの\`noto-fonts-cjk-serif\`通常版はVariable Fontを\`.ttc\`に詰めた形式でluaotfloadから読めず\`loca table not found\`になるため、ウェイト別に分かれた\`noto-fonts-cjk-serif-static\`を採用。
- kpathseaの\`\$OSFONTDIR//\`再帰展開がコロン区切りの末尾しか効かない挙動に対し、\`symlinkJoin\`でフォントを単一の\`share/fonts\`ツリーへ集約。
- ユーザの既存luaotfloadキャッシュにVF版の参照が残るため、\`TEXMFCACHE\`をパッケージ専用パスに分離して再構築させる。